### PR TITLE
Endpoint to remove keysets

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,7 +61,7 @@ EnableAutoKeyspaceCreation = true
 [cassandra]
   keyspace = "mycenae"
   consistency = "one"
-  nodes = ["182.168.0.5","182.168.0.6","182.168.0.7"]
+  nodes = ["182.168.0.2","182.168.0.3","182.168.0.4"]
   username = "cassandra"
   password = "cassandra"
   connections = 3
@@ -166,7 +166,7 @@ EnableAutoKeyspaceCreation = true
 [metadataSettings]
   numShards = 1
   replicationFactor = 1
-  url = "http://182.168.0.3:8983/solr"
+  url = "http://182.168.0.6:8983/solr"
   IDCacheTTL = -1
   QueryCacheTTL = -1
   KeysetCacheTTL = -1

--- a/lib/keyset/rest.go
+++ b/lib/keyset/rest.go
@@ -67,20 +67,20 @@ func (ks *Manager) GetKeysets(w http.ResponseWriter, r *http.Request, ps httprou
 	return
 }
 
-// DeleteKeysets - deletes a keyset
-func (ks *Manager) DeleteKeysets(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+// DeleteKeyset - deletes a keyset
+func (ks *Manager) DeleteKeyset(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
 	keysetParam := ps.ByName(constants.StringsKeyset)
 
 	if keysetParam == constants.StringsEmpty {
 		rip.AddStatsMap(r, map[string]string{"path": "/keysets/#keyset", constants.StringsKeyset: "empty"})
-		rip.Fail(w, errBadRequest("DeleteKeysets", "parameter 'keyset' cannot be empty"))
+		rip.Fail(w, errBadRequest("DeleteKeyset", "parameter 'keyset' cannot be empty"))
 		return
 	}
 
 	if !ks.keysetRegexp.MatchString(keysetParam) {
 		rip.AddStatsMap(r, map[string]string{"path": "/keysets/#keyset"})
-		rip.Fail(w, errBadRequest("DeleteKeysets", "parameter 'keyset' has an invalid format"))
+		rip.Fail(w, errBadRequest("DeleteKeyset", "parameter 'keyset' has an invalid format"))
 		return
 	}
 
@@ -100,7 +100,7 @@ func (ks *Manager) DeleteKeysets(w http.ResponseWriter, r *http.Request, ps http
 			rip.Success(w, http.StatusOK, nil)
 		}
 	} else {
-		rip.Fail(w, errNotFound("DeleteKeysets"))
+		rip.Fail(w, errNotFound("DeleteKeyset"))
 	}
 
 	return

--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -128,6 +128,7 @@ func (trest *REST) asyncStart() {
 	//KEYSETS
 	router.POST("/keysets/:keyset", trest.keyset.CreateKeyset)
 	router.HEAD("/keysets/:keyset", trest.keyset.Check)
+	router.DELETE("/keysets/:keyset", trest.keyset.DeleteKeyset)
 	router.GET("/keysets", trest.keyset.GetKeysets)
 	//DELETE
 	router.POST("/keysets/:keyset/delete/meta", trest.reader.DeleteNumberTS)

--- a/lib/structs/common.go
+++ b/lib/structs/common.go
@@ -87,7 +87,4 @@ type Settings struct {
 	StatsAnalytic                   snitch.Settings
 	MetadataSettings                metadata.Settings
 	Validation                      ValidationConfiguration
-	Probe                           struct {
-		Threshold float64
-	}
 }


### PR DESCRIPTION
- Adding API endpoint to remove keysets (deletes the cached keyset map).
- Removing probe configuration from the main configuration struct.