### PR TITLE
Memory allocation reduction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"host": "127.0.0.1",
 			"program": "${workspaceRoot}/main.go",
 			"env": {},
-			"args": ["-config", "./lab/config.toml"],
+			"args": ["-config", "./prod.toml"],
 			"showLog": true
 		}
 	]

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 57212b89f0c4882dc86d9dacde4b016fe7a0d7e02aeb2695641d154c13595794
-updated: 2020-02-11T16:44:55.2840866-03:00
+hash: 04205d3e872d6b591697eb377ad2967d62602f997f363f1d998aab4bd5e3e8ea
+updated: 2020-02-13T17:15:52.520438399-03:00
 imports:
 - name: github.com/buger/jsonparser
   version: 1a29609e0929ccd5666069e2e7213c2c69fa4ac2
@@ -18,7 +18,7 @@ imports:
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/json-iterator/go
-  version: acfec88f7a0d5140ace3dcdbee10184e3684a9e1
+  version: 7acbb404a45be33f136d6f16fe8f86ca30f1008d
 - name: github.com/julienschmidt/httprouter
   version: 348b672cd90d8190f8240323e372ecd1e66b59dc
 - name: github.com/modern-go/concurrent
@@ -54,7 +54,7 @@ imports:
 - name: github.com/uol/logh
   version: 04611a676395e92babe6a4e3f5d0aa517ec0b0d5
 - name: github.com/uol/zencached
-  version: 8077d2b7e53ea3989976041af4198c00813affd8
+  version: 5e50e73337cc89241c07dde993abfc9d733e04fa
 - name: golang.org/x/crypto
   version: 86ce3cb696783b739e41e834e2eead3e1b4aa3fb
   subpackages:
@@ -64,7 +64,7 @@ imports:
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: d101bd2416d505c0448a6ce8a282482678040a89
+  version: 12a6c2dcc1e4cb348b57847c73987099e261714b
   subpackages:
   - cpu
 - name: gopkg.in/inf.v0

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,6 +16,13 @@ import:
 - package: golang.org/x/net
   subpackages:
   - context
+- package: golang.org/x/crypto
+  subpackages:
+  - sha3
+- package: golang.org/x/sys
+  subpackages:
+  - cpu
+- package: gopkg.in/inf.v0
 - package: gopkg.in/robfig/cron.v2
   version: ~v1.0.0
 - package: github.com/uol/go-solr
@@ -33,9 +40,8 @@ import:
   version: ~1.1.1
 - package: github.com/hailocab/go-hostpool
 - package: github.com/uol/zencached
-  version: ~1.2.2
+  version: ~1.3.1
 - package: github.com/json-iterator/go
-  version: ~1.1.9
 - package: github.com/uol/logh
   version: ~1.0.1
 - package: github.com/uol/hashing

--- a/lib/collector/collector.go
+++ b/lib/collector/collector.go
@@ -172,7 +172,7 @@ func (collect *Collector) MakePacket(rcvMsg *structs.TSDBpoint, number bool) (*P
 	var err error
 	packet.Number = number
 	packet.Message = rcvMsg
-	packet.ID, err = collect.GenerateID(rcvMsg)
+	packet.ID, packet.HashID, err = collect.GenerateID(rcvMsg)
 
 	if err != nil {
 		return nil, errInternalServerError("makePacket", "error creating the tsid hash", err)
@@ -195,7 +195,7 @@ func (collect *Collector) HandlePacket(vp *Point, source string) {
 }
 
 // GenerateID - generates the unique ID from a point
-func (collect *Collector) GenerateID(rcvMsg *structs.TSDBpoint) (string, error) {
+func (collect *Collector) GenerateID(rcvMsg *structs.TSDBpoint) (string, []byte, error) {
 
 	numParameters := (len(rcvMsg.Tags) * 2) + 1
 	strParameters := make([]string, numParameters)
@@ -218,8 +218,8 @@ func (collect *Collector) GenerateID(rcvMsg *structs.TSDBpoint) (string, error) 
 
 	hash, err := hashing.GenerateSHAKE128(collect.settings.TSIDKeySize, parameters...)
 	if err != nil {
-		return constants.StringsEmpty, err
+		return constants.StringsEmpty, nil, err
 	}
 
-	return hex.EncodeToString(hash), nil
+	return hex.EncodeToString(hash), hash, nil
 }

--- a/lib/collector/meta.go
+++ b/lib/collector/meta.go
@@ -18,9 +18,9 @@ func (collect *Collector) saveMeta(packet *Point) gobol.Error {
 	var gerr gobol.Error
 
 	if packet.Number {
-		found, gerr = collect.CheckMetadata(packet.Message.Keyset, cMetaTypeNumber, packet.ID)
+		found, gerr = collect.CheckMetadata(packet.Message.Keyset, cMetaTypeNumber, packet.ID, packet.HashID)
 	} else {
-		found, gerr = collect.CheckMetadata(packet.Message.Keyset, cMetaTypeText, packet.ID)
+		found, gerr = collect.CheckMetadata(packet.Message.Keyset, cMetaTypeText, packet.ID, packet.HashID)
 	}
 
 	if gerr != nil {

--- a/lib/collector/persistence.go
+++ b/lib/collector/persistence.go
@@ -54,10 +54,10 @@ func (collect *Collector) InsertText(ksid, tsid string, timestamp int64, text st
 	return nil
 }
 
-func (collect *Collector) CheckMetadata(index, tsType, id string) (bool, gobol.Error) {
+func (collect *Collector) CheckMetadata(index, tsType, id string, idByte []byte) (bool, gobol.Error) {
 
 	start := time.Now()
-	ok, err := collect.metaStorage.CheckMetadata(index, tsType, id)
+	ok, err := collect.metaStorage.CheckMetadata(index, tsType, id, idByte)
 	if err != nil {
 		statsIndexError(index, "all", "head")
 		return false, errPersist("CheckMetadata", err)

--- a/lib/collector/structs.go
+++ b/lib/collector/structs.go
@@ -38,6 +38,7 @@ type RestErrors struct {
 type Point struct {
 	Message *structs.TSDBpoint
 	ID      string
+	HashID  []byte
 	Number  bool
 }
 

--- a/lib/keyset/keyset.go
+++ b/lib/keyset/keyset.go
@@ -59,7 +59,7 @@ func (ks *Manager) Delete(keyset string) gobol.Error {
 }
 
 // CheckKeyset - checks if keyset exists
-func (ks *Manager) CheckKeyset(keyset string) (bool, gobol.Error) {
+func (ks *Manager) CheckKeyset(keyset string) bool {
 
 	return ks.storage.CheckKeyset(keyset)
 }

--- a/lib/keyset/rest.go
+++ b/lib/keyset/rest.go
@@ -27,12 +27,7 @@ func (ks *Manager) CreateKeyset(w http.ResponseWriter, r *http.Request, ps httpr
 
 	rip.AddStatsMap(r, map[string]string{"path": "/keysets/#keyset", constants.StringsKeyset: keysetParam})
 
-	exists, gerr := ks.storage.CheckKeyset(keysetParam)
-	if gerr != nil {
-		rip.Fail(w, gerr)
-		return
-	}
-
+	exists := ks.storage.CheckKeyset(keysetParam)
 	if exists {
 		rip.Success(w, http.StatusConflict, nil)
 	} else {
@@ -50,14 +45,7 @@ func (ks *Manager) CreateKeyset(w http.ResponseWriter, r *http.Request, ps httpr
 // GetKeysets - returns all stored keysets
 func (ks *Manager) GetKeysets(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
-	keysets, gerr := ks.storage.ListKeysets()
-
-	if gerr != nil {
-		rip.AddStatsMap(r, map[string]string{"path": "/keysets"})
-		rip.Fail(w, errInternalServerError("GetKeysets", gerr))
-		return
-	}
-
+	keysets := ks.storage.ListKeysets()
 	if keysets == nil || len(keysets) == 0 {
 		rip.SuccessJSON(w, http.StatusNoContent, nil)
 	} else {
@@ -86,12 +74,7 @@ func (ks *Manager) DeleteKeyset(w http.ResponseWriter, r *http.Request, ps httpr
 
 	rip.AddStatsMap(r, map[string]string{"path": "/keysets/#keyset", constants.StringsKeyset: keysetParam})
 
-	exists, gerr := ks.storage.CheckKeyset(keysetParam)
-	if gerr != nil {
-		rip.Fail(w, gerr)
-		return
-	}
-
+	exists := ks.storage.CheckKeyset(keysetParam)
 	if exists {
 		gerr := ks.storage.DeleteKeyset(keysetParam)
 		if gerr != nil {
@@ -121,18 +104,7 @@ func (ks *Manager) Check(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		return
 	}
 
-	found, err := ks.storage.CheckKeyset(keyset)
-	if err != nil {
-		rip.AddStatsMap(
-			r,
-			map[string]string{
-				"path": "/keysets/#keyset",
-			},
-		)
-		rip.Fail(w, err)
-		return
-	}
-
+	found := ks.storage.CheckKeyset(keyset)
 	if !found {
 		rip.Fail(w, errNotFound(
 			"Check",

--- a/lib/metadata/keyset.go
+++ b/lib/metadata/keyset.go
@@ -27,23 +27,16 @@ func (sb *SolrBackend) CreateKeyset(collection string) gobol.Error {
 		return errInternalServer("CreateKeyset", err)
 	}
 
-	err = sb.deleteCachedKeysets()
-	if err != nil {
-		if logh.ErrorEnabled {
-			sb.logger.Error().Err(err).Str(constants.StringsFunc, "CreateKeyset").Msg("error deleting cached keyset map")
-		}
-		sb.statsCollectionError(collection, "create", "solr.collection.adm.error")
-		return errInternalServer("CreateKeyset", err)
-	}
+	sb.deleteCachedKeysets()
 
 	sb.statsCollectionAction(collection, "create", "solr.collection.adm", time.Since(start))
+
 	return nil
 }
 
 // DeleteKeyset - deletes a collection
 func (sb *SolrBackend) DeleteKeyset(collection string) gobol.Error {
 
-	start := time.Now()
 	err := sb.solrService.DeleteCollection(collection)
 	if err != nil {
 		if logh.ErrorEnabled {
@@ -53,105 +46,29 @@ func (sb *SolrBackend) DeleteKeyset(collection string) gobol.Error {
 		return errInternalServer("DeleteKeyset", err)
 	}
 
-	err = sb.deleteCachedKeysets()
-	if err != nil {
-		if logh.ErrorEnabled {
-			sb.logger.Error().Err(err).Str(constants.StringsFunc, "DeleteKeyset").Msg("error deleting cached keyset map")
-		}
-		sb.statsCollectionError(collection, "delete", "solr.collection.adm.error")
-		return errInternalServer("DeleteKeyset", err)
-	}
+	sb.deleteCachedKeysets()
 
-	sb.statsCollectionAction(collection, "delete", "solr.collection.adm", time.Since(start))
 	return nil
 }
 
 // ListKeysets - list all keysets
-func (sb *SolrBackend) ListKeysets() ([]string, gobol.Error) {
+func (sb *SolrBackend) ListKeysets() []string {
 
-	start := time.Now()
-
-	cachedKeysets, err := sb.getCachedKeysets()
-	if err != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return nil, errInternalServer("ListKeysets", err)
-	}
-
-	if cachedKeysets != nil && len(cachedKeysets) > 0 {
-		sb.statsCollectionAction("all", "list", "solr.collection.adm", time.Since(start))
-		return cachedKeysets, nil
-	}
-
-	keysets, e := sb.solrService.ListCollections()
-	if e != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return nil, errInternalServer("ListKeysets", e)
-	}
-
-	filteredKeysets := []string{}
-	for i := 0; i < len(keysets); i++ {
-		if _, ok := sb.blacklistedKeysetMap[keysets[i]]; !ok {
-			filteredKeysets = append(filteredKeysets, keysets[i])
-		}
-	}
-
-	err = sb.cacheKeysets(filteredKeysets)
-	if err != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return nil, errInternalServer("ListKeysets", e)
-	}
-
-	sb.statsCollectionAction("all", "list", "solr.collection.adm", time.Since(start))
-	return filteredKeysets, nil
+	return sb.getCachedKeysets()
 }
 
 // CheckKeyset - verifies if an index exists
-func (sb *SolrBackend) CheckKeyset(keyset string) (bool, gobol.Error) {
+func (sb *SolrBackend) CheckKeyset(keyset string) bool {
 
-	keysets, err := sb.getCachedKeysets()
-	if err != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return false, errInternalServer("CheckKeyset", err)
-	}
+	keysets := sb.getCachedKeysets()
 
 	if len(keysets) > 0 {
 		for _, k := range keysets {
 			if k == keyset {
-				return true, nil
+				return true
 			}
 		}
-
-		return false, nil
 	}
 
-	start := time.Now()
-
-	keysets, e := sb.solrService.ListCollections()
-	if e != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return false, errInternalServer("CheckKeyset", e)
-	}
-
-	sb.statsCollectionAction("all", "list", "solr.collection.adm", time.Since(start))
-
-	filteredKeysets := []string{}
-	for i := 0; i < len(keysets); i++ {
-		if _, ok := sb.blacklistedKeysetMap[keysets[i]]; !ok {
-			filteredKeysets = append(filteredKeysets, keysets[i])
-		}
-	}
-
-	err = sb.cacheKeysets(filteredKeysets)
-	if err != nil {
-		sb.statsCollectionError("all", "list", "solr.collection.adm.error")
-		return false, errInternalServer("CheckKeyset", e)
-	}
-
-	for _, k := range keysets {
-		if k == keyset {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return false
 }

--- a/lib/metadata/metadata.go
+++ b/lib/metadata/metadata.go
@@ -17,10 +17,10 @@ type Backend interface {
 	DeleteKeyset(name string) gobol.Error
 
 	// ListKeyset - list all keyset
-	ListKeysets() ([]string, gobol.Error)
+	ListKeysets() []string
 
 	// CheckKeyset - verifies if a keyset exists
-	CheckKeyset(keyset string) (bool, gobol.Error)
+	CheckKeyset(keyset string) bool
 
 	// FilterTagValues - filter tag values from a collection
 	FilterTagValues(collection, prefix string, maxResults int) ([]string, int, gobol.Error)
@@ -39,7 +39,7 @@ type Backend interface {
 	AddDocument(collection string, metadata *Metadata) gobol.Error
 
 	// CheckMetadata - verifies if a metadata exists
-	CheckMetadata(collection, tsType, tsid string) (bool, gobol.Error)
+	CheckMetadata(collection, tsType, tsid string, tsidBytes []byte) (bool, gobol.Error)
 
 	// SetRegexValue - add slashes to the value
 	SetRegexValue(value string) string
@@ -70,9 +70,9 @@ type Settings struct {
 	NumShards           int
 	ReplicationFactor   int
 	URL                 string
-	IDCacheTTL          int32
-	QueryCacheTTL       int32
-	KeysetCacheTTL      int32
+	IDCacheTTL          int
+	QueryCacheTTL       int
+	KeysetCacheTTL      int
 	MaxReturnedMetadata int
 	ZookeeperConfig     string
 	BlacklistedKeysets  []string

--- a/lib/plot/plot_meta.go
+++ b/lib/plot/plot_meta.go
@@ -10,10 +10,7 @@ import (
 
 func (plot *Plot) validateKeyset(keyset string) gobol.Error {
 
-	found, gerr := plot.persist.metaStorage.CheckKeyset(keyset)
-	if gerr != nil {
-		return gerr
-	}
+	found := plot.persist.metaStorage.CheckKeyset(keyset)
 	if !found {
 		return errNotFound("validateKeyset")
 	}

--- a/lib/plot/rest_exp.go
+++ b/lib/plot/rest_exp.go
@@ -232,11 +232,7 @@ func (plot *Plot) expressionParse(w http.ResponseWriter, expQuery ExpParse) {
 			return
 		}
 
-		found, gerr := plot.persist.metaStorage.CheckKeyset(expQuery.Keyset)
-		if gerr != nil {
-			rip.Fail(w, gerr)
-			return
-		}
+		found := plot.persist.metaStorage.CheckKeyset(expQuery.Keyset)
 		if !found {
 			gerr := errValidationS("expressionParse", `ksid not found`)
 			rip.Fail(w, gerr)
@@ -361,11 +357,7 @@ func (plot *Plot) expressionExpand(w http.ResponseWriter, keyset string, expQuer
 		return
 	}
 
-	found, gerr := plot.persist.metaStorage.CheckKeyset(keyset)
-	if gerr != nil {
-		rip.Fail(w, gerr)
-		return
-	}
+	found := plot.persist.metaStorage.CheckKeyset(keyset)
 	if !found {
 		gerr := errNotFound("expressionExpand")
 		rip.Fail(w, gerr)

--- a/lib/telnet/netdata.go
+++ b/lib/telnet/netdata.go
@@ -269,18 +269,7 @@ func (nh *NetdataHandler) Handle(line string) {
 					Value: tagMatches[i][2],
 				}
 
-				dup := false
-				for i, k := range point.Tags {
-					if k.Name == tag.Name {
-						point.Tags[i].Value = tag.Value
-						dup = true
-						break
-					}
-				}
-
-				if !dup {
-					point.Tags = append(point.Tags, tag)
-				}
+				point.Tags = append(point.Tags, tag)
 			}
 		}
 	}

--- a/lib/telnet/opentsdb.go
+++ b/lib/telnet/opentsdb.go
@@ -158,18 +158,15 @@ func (otsdbh *OpenTSDBHandler) Handle(line string) {
 			Value: tagMatches[i][2],
 		}
 
-		dup := false
-		for i, k := range point.Tags {
-			if k.Name == tag.Name {
-				point.Tags[i].Value = tag.Value
-				dup = true
-				break
-			}
-		}
+		point.Tags = append(point.Tags, tag)
+	}
 
-		if !dup {
-			point.Tags = append(point.Tags, tag)
+	gerr = otsdbh.validationService.ValidateTags(&point)
+	if gerr != nil {
+		if !otsdbh.telnetConfig.SilenceLogs && logh.ErrorEnabled {
+			otsdbh.logger.Error().Err(gerr).Msgf("tags validation failure: %s", line)
 		}
+		return
 	}
 
 	if !ksidFound {

--- a/lib/validation/error.go
+++ b/lib/validation/error.go
@@ -47,6 +47,7 @@ var (
 	errTextTypeExpected    = errSimpleBadRequest("ValidateType", `Wrong Format: Field "text" is required.`)
 	errMaxTextValueSize    = errSimpleBadRequest("ValidateType", `Wrong Format: Field "text" has exceeded the maximum number of characters allowed`)
 	errNoTags              = errSimpleBadRequest("ValidateTags", `Wrong Format: At least one tag is required.`)
+	errDuplicatedTags      = errSimpleBadRequest("ValidateTags", `Wrong Format: Duplicated tags.`)
 	errNoUserTags          = errSimpleBadRequest("ValidateTags", `Wrong Format: At least one tag other than "ksid" and "ttl" is required.`)
 	errNoKeysetTag         = errSimpleBadRequest("ValidateKeyset", `Wrong Format: Tag "ksid" is required.`)
 	errInvalidKeysetFormat = errSimpleBadRequest("ValidateKeyset", `Wrong Format: Field "ksid" has a invalid format.`)

--- a/lib/validation/parser.go
+++ b/lib/validation/parser.go
@@ -1,12 +1,13 @@
 package validation
 
 import (
+	"strings"
+
 	"github.com/buger/jsonparser"
 	"github.com/uol/gobol"
 	"github.com/uol/logh"
 	"github.com/uol/mycenae/lib/constants"
 	"github.com/uol/mycenae/lib/structs"
-	"strings"
 )
 
 const (
@@ -175,18 +176,7 @@ func (v *Service) ParsePoint(function string, isNumber bool, data []byte) (*stru
 			}
 		}
 
-		dup := false
-		for i, k := range p.Tags {
-			if k.Name == tag.Name {
-				p.Tags[i].Value = tag.Value
-				dup = true
-				break
-			}
-		}
-
-		if !dup {
-			p.Tags = append(p.Tags, tag)
-		}
+		p.Tags = append(p.Tags, tag)
 
 		return nil
 

--- a/lib/validation/validation.go
+++ b/lib/validation/validation.go
@@ -116,6 +116,17 @@ func (v *Service) ValidateTags(p *structs.TSDBpoint) gobol.Error {
 		return errNoUserTags
 	}
 
+	tagMap := map[string]struct{}{}
+	for i := 0; i < lt; i++ {
+		if _, ok := tagMap[p.Tags[i].Name]; !ok {
+			tagMap[p.Tags[i].Name] = struct{}{}
+		} else {
+			return errDuplicatedTags
+		}
+	}
+
+	tagMap = nil
+
 	return nil
 }
 
@@ -130,11 +141,7 @@ func (v *Service) ValidateKeyset(keyset string) gobol.Error {
 		return errInvalidKeysetFormat
 	}
 
-	keysetExists, gerr := v.metadataStorage.CheckKeyset(keyset)
-	if gerr != nil {
-		return gerr
-	}
-
+	keysetExists := v.metadataStorage.CheckKeyset(keyset)
 	if !keysetExists {
 		return errInexistentKeyset
 	}

--- a/main.go
+++ b/main.go
@@ -346,18 +346,12 @@ func createKeysetManager(conf *structs.Settings, timeseriesStats *tsstats.StatsT
 	}
 
 	for _, v := range conf.DefaultKeysets {
-		exists, err := metadataStorage.CheckKeyset(v)
-		if err != nil {
-			if logh.FatalEnabled {
-				logger.Fatal().Err(err).Msgf("error checking keyset '%s' existence", v)
-			}
-			os.Exit(1)
-		}
+		exists := metadataStorage.CheckKeyset(v)
 		if !exists {
 			if logh.InfoEnabled {
 				logger.Info().Msgf("creating default keyset '%s'", v)
 			}
-			err = keyset.Create(v)
+			err := keyset.Create(v)
 			if err != nil {
 				if logh.FatalEnabled {
 					logger.Fatal().Err(err).Msgf("error creating keyset '%s'", v)

--- a/prod.toml
+++ b/prod.toml
@@ -80,7 +80,7 @@ EnableAutoKeyspaceCreation = false
   readBuffer = 1048576
 
 [HTTPserver]
-  port = 8080
+  port = 80
   bind = "0.0.0.0"
   EnableProfiling = false
   ForceErrorAsDebug = true
@@ -163,7 +163,7 @@ EnableAutoKeyspaceCreation = false
     ttl = "365"
     ksid = "pdeng_analytics"
 
-[metadataSettings]
+[metadataSettings] 
   numShards = 4
   replicationFactor = 1
   url = "http://10.128.7.28:8983/solr"
@@ -176,17 +176,20 @@ EnableAutoKeyspaceCreation = false
   CacheKeyHashSize = 16
 
 [memcached]
-  # the nodes
-  Nodes = ["10.128.5.92:11211","10.128.5.93:11211","10.128.5.94:11211","10.128.5.95:11211"]
-	
+  # the memcached node list
+  Nodes =  ["182.168.0.4:11211","182.168.0.3:11211","182.168.0.2:11211"]
+
   # the number of idle connections per host
-  NumConnectionsPerNode = 10
-  
+  NumConnectionsPerNode = 8
+
   # the time duration between connection retries
   ReconnectionTimeout = "1s"
 
-  # the max time duration to wait a read or write operation
-  ReadWriteTimeout = "3s"
+  # the max time duration to wait a write operation
+  MaxWriteTimeout = "3s"
+
+  # the max time duration to wait a read operation
+  MaxReadTimeout = "120s"
 
   # the maximum number of write retries
   MaxWriteRetries = 3
@@ -200,4 +203,4 @@ EnableAutoKeyspaceCreation = false
   propertyRegexp   = "^[0-9A-Za-z-\\._\\%\\&\\#\\;\\/]+$"
   keysetNameRegexp = "^[a-z_]{1}[a-z0-9_\\-]+[a-z0-9]{1}$"
   defaultTTL       = 1
-  MaxPropertySize  = 64
+  MaxPropertySize  = 256

--- a/rpm/mycenae.spec
+++ b/rpm/mycenae.spec
@@ -5,7 +5,7 @@
 %define projectname mycenae
 %define build_timestamp %(date +"%Y%m%d%H%M")
 Name:      %{projectname}
-Version:   2.26.1
+Version:   2.26.2
 Release:   %{build_timestamp}
 
 Packager:  UOL - Universo Online S.A.

--- a/rpm/mycenae.spec
+++ b/rpm/mycenae.spec
@@ -5,7 +5,7 @@
 %define projectname mycenae
 %define build_timestamp %(date +"%Y%m%d%H%M")
 Name:      %{projectname}
-Version:   2.26.0
+Version:   2.26.1
 Release:   %{build_timestamp}
 
 Packager:  UOL - Universo Online S.A.

--- a/tests/restv2Text_test.go
+++ b/tests/restv2Text_test.go
@@ -403,17 +403,17 @@ func TestRESTv2TextPayloadsWithSameMetricTagsTimestampTwoEqualTags(t *testing.T)
 	hashID := tools.GetTextHashFromMetricAndTags(metric, tags)
 
 	statusCode, _ := mycenaeTools.HTTP.POSTstring("api/text/put", payload1)
-	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
 
 	statusCode, _ = mycenaeTools.HTTP.POSTstring("api/text/put", payload2)
-	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
 	time.Sleep(tools.Sleep3)
 
-	assertMycenaeText(t, ksMycenae, timestamp, timestamp, value2, hashID)
+	assertMycenaeTextEmpty(t, ksMycenae, timestamp, timestamp, hashID)
 
-	assertCassandraText(t, hashID, value2, timestamp, timestamp)
+	assertCassandraTextEmpty(t, hashID, timestamp, timestamp)
 
-	assertElasticText(t, ksMycenae, metric, tags, hashID)
+	assertElasticTextEmpty(t, ksMycenae, metric, tags, hashID)
 }
 
 func TestRESTv2TextPayloadWithTwoTagsSameKeyAndDifferentValues(t *testing.T) {
@@ -438,16 +438,16 @@ func TestRESTv2TextPayloadWithTwoTagsSameKeyAndDifferentValues(t *testing.T) {
 	tags := map[string]string{p.TagKey: tagValue2, "ksid": ksMycenae, "ttl": "1"}
 
 	statusCode, _ := mycenaeTools.HTTP.POSTstring("api/text/put", payload)
-	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
 	time.Sleep(tools.Sleep3)
 
 	hashID := tools.GetTextHashFromMetricAndTags(p.Metric, tags)
 
-	assertMycenaeText(t, ksMycenae, *p.Timestamp, *p.Timestamp, *p.Text, hashID)
+	assertMycenaeTextEmpty(t, ksMycenae, *p.Timestamp, *p.Timestamp, hashID)
 
-	assertCassandraText(t, hashID, *p.Text, *p.Timestamp, *p.Timestamp)
+	assertCassandraTextEmpty(t, hashID, *p.Timestamp, *p.Timestamp)
 
-	assertElasticText(t, ksMycenae, p.Metric, tags, hashID)
+	assertElasticTextEmpty(t, ksMycenae, p.Metric, tags, hashID)
 
 	count := mycenaeTools.Solr.Timeseries.GetTextTagValuePost(ksMycenae, p.TagValue)
 	assert.Equal(t, 0, count)

--- a/tests/restv2_test.go
+++ b/tests/restv2_test.go
@@ -346,15 +346,15 @@ func TestRESTv2PayloadsWithSameMetricTagsTimestampTwoEqualTags(t *testing.T) {
 	hashID := tools.GetHashFromMetricAndTags(metric, tags)
 
 	statusCode, _ := mycenaeTools.HTTP.POSTstring("api/put", payload1)
-	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
 
 	statusCode, _ = mycenaeTools.HTTP.POSTstring("api/put", payload2)
-	assert.Equal(t, http.StatusNoContent, statusCode)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
 	time.Sleep(tools.Sleep3)
 
-	assertMycenae(t, ksMycenae, timestamp, timestamp, float32(value2), hashID)
+	assertMycenaeEmpty(t, ksMycenae, timestamp, timestamp, hashID)
 
-	assertElastic(t, ksMycenae, metric, tags, hashID)
+	assertElasticEmpty(t, ksMycenae, metric, tags, hashID)
 }
 
 func TestRESTv2PayloadWithStringValue(t *testing.T) {

--- a/tests/udpv2_test.go
+++ b/tests/udpv2_test.go
@@ -277,9 +277,9 @@ func TestUDPv2PayloadsWithSameMetricTagsTimestampTwoEqualTags(t *testing.T) {
 	mycenaeTools.UDP.SendString(payload2)
 	time.Sleep(tools.Sleep2)
 
-	assertMycenae(t, ksMycenae, timestamp, timestamp, float32(value2), hashID)
+	assertMycenaeEmpty(t, ksMycenae, timestamp, timestamp, hashID)
 
-	assertElastic(t, ksMycenae, metric, tags, hashID)
+	assertElasticEmpty(t, ksMycenae, metric, tags, hashID)
 }
 
 func TestUDPv2PayloadWithStringValue(t *testing.T) {

--- a/vendor/github.com/json-iterator/go/config.go
+++ b/vendor/github.com/json-iterator/go/config.go
@@ -183,11 +183,11 @@ func (cfg *frozenConfig) validateJsonRawMessage(extension EncoderExtension) {
 	encoder := &funcEncoder{func(ptr unsafe.Pointer, stream *Stream) {
 		rawMessage := *(*json.RawMessage)(ptr)
 		iter := cfg.BorrowIterator([]byte(rawMessage))
+		defer cfg.ReturnIterator(iter)
 		iter.Read()
-		if iter.Error != nil {
+		if iter.Error != nil && iter.Error != io.EOF {
 			stream.WriteRaw("null")
 		} else {
-			cfg.ReturnIterator(iter)
 			stream.WriteRaw(string(rawMessage))
 		}
 	}, func(ptr unsafe.Pointer) bool {

--- a/vendor/github.com/json-iterator/go/extra/naming_strategy.go
+++ b/vendor/github.com/json-iterator/go/extra/naming_strategy.go
@@ -18,6 +18,9 @@ type namingStrategyExtension struct {
 
 func (extension *namingStrategyExtension) UpdateStructDescriptor(structDescriptor *jsoniter.StructDescriptor) {
 	for _, binding := range structDescriptor.Fields {
+		if unicode.IsLower(rune(binding.Field.Name()[0])) {
+			continue
+		}
 		tag, hastag := binding.Field.Tag().Lookup("json")
 		if hastag {
 			tagParts := strings.Split(tag, ",")

--- a/vendor/github.com/json-iterator/go/extra/naming_strategy_test.go
+++ b/vendor/github.com/json-iterator/go/extra/naming_strategy_test.go
@@ -48,3 +48,17 @@ func Test_set_naming_strategy_with_omitempty(t *testing.T) {
 	should.Nil(err)
 	should.Equal(`{"user_name":"taowen"}`, string(output))
 }
+
+func Test_set_naming_strategy_with_private_field(t *testing.T) {
+	should := require.New(t)
+	SetNamingStrategy(LowerCaseWithUnderscores)
+	output, err := jsoniter.Marshal(struct {
+		UserName string
+		userId   int
+	}{
+		UserName: "allen",
+		userId:   100,
+	})
+	should.Nil(err)
+	should.Equal(`{"user_name":"allen"}`, string(output))
+}

--- a/vendor/github.com/json-iterator/go/iter_object.go
+++ b/vendor/github.com/json-iterator/go/iter_object.go
@@ -150,7 +150,7 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 		if c == '}' {
 			return iter.decrementDepth()
 		}
-		iter.ReportError("ReadObjectCB", `expect " after }, but found `+string([]byte{c}))
+		iter.ReportError("ReadObjectCB", `expect " after {, but found `+string([]byte{c}))
 		iter.decrementDepth()
 		return false
 	}
@@ -206,7 +206,7 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 		if c == '}' {
 			return iter.decrementDepth()
 		}
-		iter.ReportError("ReadMapCB", `expect " after }, but found `+string([]byte{c}))
+		iter.ReportError("ReadMapCB", `expect " after {, but found `+string([]byte{c}))
 		iter.decrementDepth()
 		return false
 	}

--- a/vendor/github.com/json-iterator/go/value_tests/raw_message_test.go
+++ b/vendor/github.com/json-iterator/go/value_tests/raw_message_test.go
@@ -7,6 +7,9 @@ import (
 func init() {
 	marshalCases = append(marshalCases,
 		json.RawMessage("{}"),
+		json.RawMessage("12345"),
+		json.RawMessage("3.14"),
+		json.RawMessage("-0.5e10"),
 		struct {
 			Env   string          `json:"env"`
 			Extra json.RawMessage `json:"extra,omitempty"`

--- a/vendor/github.com/uol/zencached/benchmark_test.go
+++ b/vendor/github.com/uol/zencached/benchmark_test.go
@@ -1,0 +1,26 @@
+package zencached_test
+
+import (
+	"testing"
+
+	"github.com/uol/zencached"
+)
+
+func Benchmark(b *testing.B) {
+
+	z := createZencached(nil)
+	key := []byte("benchmark")
+	value := []byte("benchmark")
+	route := []byte{0}
+
+	for n := 0; n < b.N; n++ {
+		_, err := z.Storage(zencached.Set, route, key, value, defaultTTL)
+		if err != nil {
+			panic(err)
+		}
+		_, _, err = z.Get(route, key)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/vendor/github.com/uol/zencached/zencached.go
+++ b/vendor/github.com/uol/zencached/zencached.go
@@ -135,10 +135,10 @@ func (z *Zencached) GetTelnetConnByNodeIndex(index int) (telnetConn *Telnet) {
 }
 
 // GetTelnetConnection - returns an idle telnet connection
-func (z *Zencached) GetTelnetConnection(routerHash []byte, key string) (telnetConn *Telnet, index int) {
+func (z *Zencached) GetTelnetConnection(routerHash []byte, key []byte) (telnetConn *Telnet, index int) {
 
 	if routerHash == nil {
-		routerHash = []byte(key)
+		routerHash = key
 	}
 
 	if len(routerHash) == 0 {

--- a/vendor/github.com/uol/zencached/zencached_cluster.go
+++ b/vendor/github.com/uol/zencached/zencached_cluster.go
@@ -8,7 +8,7 @@ import "math/rand"
 //
 
 // ClusterStorage - performs an full operation operation
-func (z *Zencached) ClusterStorage(cmd memcachedCommand, key string, value string, ttl uint16) ([]bool, []error) {
+func (z *Zencached) ClusterStorage(cmd memcachedCommand, key, value, ttl []byte) ([]bool, []error) {
 
 	stored := make([]bool, z.numNodeTelnetConns)
 	errors := make([]error, z.numNodeTelnetConns)
@@ -25,7 +25,7 @@ func (z *Zencached) ClusterStorage(cmd memcachedCommand, key string, value strin
 }
 
 // ClusterGet - returns a full replicated key stored in the cluster
-func (z *Zencached) ClusterGet(key string) (string, bool, error) {
+func (z *Zencached) ClusterGet(key []byte) ([]byte, bool, error) {
 
 	index := rand.Intn(z.numNodeTelnetConns)
 
@@ -36,7 +36,7 @@ func (z *Zencached) ClusterGet(key string) (string, bool, error) {
 }
 
 // ClusterDelete - deletes a key from all cluster nodes
-func (z *Zencached) ClusterDelete(key string) ([]bool, []error) {
+func (z *Zencached) ClusterDelete(key []byte) ([]bool, []error) {
 
 	deleted := make([]bool, z.numNodeTelnetConns)
 	errors := make([]error, z.numNodeTelnetConns)

--- a/vendor/github.com/uol/zencached/zencached_ops.go
+++ b/vendor/github.com/uol/zencached/zencached_ops.go
@@ -3,6 +3,7 @@ package zencached
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -15,16 +16,15 @@ import (
 
 // memcached commands and constants
 const (
-	storageFmt string = "%s %s 0 %d %d\r\n%s\r\n"
-	getFmt     string = "get %s\r\n"
-	deleteFmt  string = "delete %s\r\n"
-	empty      string = ""
+	lineBreaksR byte = '\r'
+	lineBreaksN byte = '\n'
+	whiteSpace  byte = ' '
+	zero        byte = '0'
 )
 
 // memcached responses
 var (
-	lineBreaks []byte = []byte{[]byte("\r")[0], []byte("\n")[0]}
-
+	doubleBreaks []byte = []byte{lineBreaksR, lineBreaksN}
 	// responses
 	mcrValue     []byte = []byte("VALUE") // the only prefix
 	mcrStored    []byte = []byte("STORED")
@@ -34,26 +34,27 @@ var (
 	mcrDeleted   []byte = []byte("DELETED")
 
 	// response set
-	mcrResponseSetStored  [][]byte = [][]byte{mcrStored, mcrNotStored}
-	mcrResponseSetGet     [][]byte = [][]byte{mcrValue, mcrEnd}
-	mcrResponseSetDeleted [][]byte = [][]byte{mcrDeleted, mcrNotFound}
+	mcrStoredResponseSet      [][]byte = [][]byte{mcrStored, mcrNotStored}
+	mcrGetCheckResponseSet    [][]byte = [][]byte{mcrEnd}
+	mcrGetCheckEndResponseSet [][]byte = [][]byte{mcrValue, mcrEnd}
+	mcrDeletedResponseSet     [][]byte = [][]byte{mcrDeleted, mcrNotFound}
 )
 
 // memcachedCommand type
-type memcachedCommand string
+type memcachedCommand []byte
 
-const (
+var (
 	// Add - add some key if it not exists
-	Add memcachedCommand = "add"
+	Add memcachedCommand = memcachedCommand("add")
 
 	// Set - sets a key if it exists or not
-	Set memcachedCommand = "set"
+	Set memcachedCommand = memcachedCommand("set")
 
 	// get - return a key if it exists or not
-	get memcachedCommand = "get"
+	get memcachedCommand = memcachedCommand("get")
 
 	// delete - return a key if it exists or not
-	delete memcachedCommand = "delete"
+	delete memcachedCommand = memcachedCommand("delete")
 )
 
 // countOperation - send the operation count metric
@@ -68,7 +69,7 @@ func (z *Zencached) countOperation(host string, operation memcachedCommand) {
 }
 
 // executeSend - sends a message to memcached
-func (z *Zencached) executeSend(telnetConn *Telnet, operation memcachedCommand, renderedCmd string) error {
+func (z *Zencached) executeSend(telnetConn *Telnet, operation memcachedCommand, renderedCmd []byte) error {
 
 	if !z.enableMetrics {
 
@@ -98,15 +99,15 @@ func (z *Zencached) executeSend(telnetConn *Telnet, operation memcachedCommand, 
 }
 
 // checkResponse - checks the memcached response
-func (z *Zencached) checkResponse(telnetConn *Telnet, responseSet [][]byte, operation memcachedCommand, renderedCmd string) (bool, [][]byte, error) {
+func (z *Zencached) checkResponse(telnetConn *Telnet, checkReadSet, checkResponseSet [][]byte, operation memcachedCommand) (bool, []byte, error) {
 
-	response, err := telnetConn.Read(responseSet)
+	response, err := telnetConn.Read(checkReadSet)
 	if err != nil {
 		return false, nil, err
 	}
 
-	if !bytes.HasPrefix(response[0], responseSet[0]) {
-		if !bytes.Equal(response[0], responseSet[1]) {
+	if !bytes.HasPrefix(response, checkResponseSet[0]) {
+		if !bytes.Contains(response, checkResponseSet[1]) {
 			return false, nil, fmt.Errorf("memcached operation error on command:\n%s", operation)
 		}
 
@@ -134,8 +135,31 @@ func (z *Zencached) checkResponse(telnetConn *Telnet, responseSet [][]byte, oper
 	return true, response, nil
 }
 
+// renderStorageCmd - like Sprintf, but in bytes
+func (z *Zencached) renderStorageCmd(cmd memcachedCommand, key, value, ttl []byte) []byte {
+
+	length := strconv.Itoa(len(value))
+
+	buffer := bytes.Buffer{}
+	buffer.Grow(len(cmd) + len(key) + len(value) + len(ttl) + len(length) + 4 + (len(doubleBreaks) * 2) + 1)
+	buffer.Write(cmd)
+	buffer.WriteByte(whiteSpace)
+	buffer.Write(key)
+	buffer.WriteByte(whiteSpace)
+	buffer.WriteByte(zero)
+	buffer.WriteByte(whiteSpace)
+	buffer.Write(ttl)
+	buffer.WriteByte(whiteSpace)
+	buffer.WriteString(length)
+	buffer.Write(doubleBreaks)
+	buffer.Write(value)
+	buffer.Write(doubleBreaks)
+
+	return buffer.Bytes()
+}
+
 // Storage - performs an storage operation
-func (z *Zencached) Storage(cmd memcachedCommand, routerHash []byte, key string, value string, ttl uint16) (bool, error) {
+func (z *Zencached) Storage(cmd memcachedCommand, routerHash, key, value, ttl []byte) (bool, error) {
 
 	telnetConn, index := z.GetTelnetConnection(routerHash, key)
 	defer z.ReturnTelnetConnection(telnetConn, index)
@@ -144,19 +168,18 @@ func (z *Zencached) Storage(cmd memcachedCommand, routerHash []byte, key string,
 }
 
 // baseStorage - base storage function
-func (z *Zencached) baseStorage(telnetConn *Telnet, cmd memcachedCommand, key string, value string, ttl uint16) (bool, error) {
+func (z *Zencached) baseStorage(telnetConn *Telnet, cmd memcachedCommand, key, value, ttl []byte) (bool, error) {
 
 	if z.enableMetrics {
 		z.countOperation(telnetConn.GetHost(), cmd)
 	}
 
-	renderedCmd := fmt.Sprintf(storageFmt, cmd, key, ttl, len(value), value)
-	err := z.executeSend(telnetConn, cmd, renderedCmd)
+	err := z.executeSend(telnetConn, cmd, z.renderStorageCmd(cmd, key, value, ttl))
 	if err != nil {
 		return false, err
 	}
 
-	wasStored, _, err := z.checkResponse(telnetConn, mcrResponseSetStored, cmd, renderedCmd)
+	wasStored, _, err := z.checkResponse(telnetConn, mcrStoredResponseSet, mcrStoredResponseSet, cmd)
 	if err != nil {
 		return false, err
 	}
@@ -164,8 +187,21 @@ func (z *Zencached) baseStorage(telnetConn *Telnet, cmd memcachedCommand, key st
 	return wasStored, nil
 }
 
+// renderKeyOnlyCmd - like Sprintf, but in bytes
+func (z *Zencached) renderKeyOnlyCmd(cmd memcachedCommand, key []byte) []byte {
+
+	buffer := bytes.Buffer{}
+	buffer.Grow(len(cmd) + len(key) + 1 + len(doubleBreaks))
+	buffer.Write(cmd)
+	buffer.WriteByte(whiteSpace)
+	buffer.Write(key)
+	buffer.Write(doubleBreaks)
+
+	return buffer.Bytes()
+}
+
 // Get - performs a get operation
-func (z *Zencached) Get(routerHash []byte, key string) (string, bool, error) {
+func (z *Zencached) Get(routerHash []byte, key []byte) ([]byte, bool, error) {
 
 	telnetConn, index := z.GetTelnetConnection(routerHash, key)
 	defer z.ReturnTelnetConnection(telnetConn, index)
@@ -174,30 +210,58 @@ func (z *Zencached) Get(routerHash []byte, key string) (string, bool, error) {
 }
 
 // baseGet - the base get operation
-func (z *Zencached) baseGet(telnetConn *Telnet, key string) (string, bool, error) {
+func (z *Zencached) baseGet(telnetConn *Telnet, key []byte) ([]byte, bool, error) {
 
 	if z.enableMetrics {
 		z.countOperation(telnetConn.GetHost(), get)
 	}
 
-	renderedCmd := fmt.Sprintf(getFmt, key)
-	err := z.executeSend(telnetConn, get, renderedCmd)
+	err := z.executeSend(telnetConn, get, z.renderKeyOnlyCmd(get, key))
 	if err != nil {
-		return empty, false, err
+		return nil, false, err
 	}
 
-	exists, response, err := z.checkResponse(telnetConn, mcrResponseSetGet, get, renderedCmd)
+	exists, response, err := z.checkResponse(telnetConn, mcrGetCheckResponseSet, mcrGetCheckEndResponseSet, get)
 	if !exists || err != nil {
-		return empty, false, err
+		return nil, false, err
 	}
 
-	storedValue := string(response[1])
+	start, end, err := z.extractValue([]byte(response))
+	if err != nil {
+		return nil, false, err
+	}
 
-	return storedValue, true, nil
+	return response[start:end], true, nil
+}
+
+// extractValue - extracts a value from the response
+func (z *Zencached) extractValue(response []byte) (start, end int, err error) {
+
+	start = -1
+	end = -1
+
+	for i := 0; i < len(response); i++ {
+		if start == -1 && response[i] == lineBreaksN {
+			start = i + 1
+		} else if start >= 0 && response[i] == lineBreaksR {
+			end = i
+			break
+		}
+	}
+
+	if start == -1 {
+		err = fmt.Errorf("no value found")
+	}
+
+	if end == -1 {
+		end = len(response) - 1
+	}
+
+	return
 }
 
 // Delete - performs a delete operation
-func (z *Zencached) Delete(routerHash []byte, key string) (bool, error) {
+func (z *Zencached) Delete(routerHash []byte, key []byte) (bool, error) {
 
 	telnetConn, index := z.GetTelnetConnection(routerHash, key)
 	defer z.ReturnTelnetConnection(telnetConn, index)
@@ -206,19 +270,18 @@ func (z *Zencached) Delete(routerHash []byte, key string) (bool, error) {
 }
 
 // baseDelete - base delete operation
-func (z *Zencached) baseDelete(telnetConn *Telnet, key string) (bool, error) {
+func (z *Zencached) baseDelete(telnetConn *Telnet, key []byte) (bool, error) {
 
 	if z.enableMetrics {
 		z.countOperation(telnetConn.GetHost(), delete)
 	}
 
-	renderedCmd := fmt.Sprintf(deleteFmt, key)
-	err := z.executeSend(telnetConn, delete, renderedCmd)
+	err := z.executeSend(telnetConn, delete, z.renderKeyOnlyCmd(delete, key))
 	if err != nil {
 		return false, err
 	}
 
-	exists, _, err := z.checkResponse(telnetConn, mcrResponseSetDeleted, delete, renderedCmd)
+	exists, _, err := z.checkResponse(telnetConn, mcrDeletedResponseSet, mcrDeletedResponseSet, delete)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/golang.org/x/sys/unix/syscall_linux_mips64x.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux_mips64x.go
@@ -224,3 +224,8 @@ func Poll(fds []PollFd, timeout int) (n int, err error) {
 	}
 	return poll(&fds[0], len(fds), timeout)
 }
+
+func InotifyInit() (fd int, err error) {
+        return InotifyInit1(0)
+}
+


### PR DESCRIPTION
- Updating zencached library to reduce the memory allocation.
- Adding duplicated tag key check in validations.
- Updating automated tests.