### PR TITLE
Avoiding check keyset validation fail when keyset do exists + stats for cached keysets update fail

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -184,7 +184,7 @@ ClusteringOrder = "DESC"
   [[stats.backends]]
     addHostTag    = true
     cycleDuration = "15s"
-    host          = "10.128.5.208"
+    host          = "loghost"
     port          = 8082
     storage       = "normal"
     transport     = "number"
@@ -197,7 +197,7 @@ ClusteringOrder = "DESC"
   [[stats.backends]]
     addHostTag    = true
     cycleDuration = "15s"
-    host          = "10.128.5.208"
+    host          = "loghost"
     port          = 8082
     storage       = "archive"
     transport     = "number"
@@ -223,7 +223,7 @@ ClusteringOrder = "DESC"
 [metadataSettings]
   numShards = 1
   replicationFactor = 1
-  url = "http://182.168.0.6:8983/solr"
+  url = "http://182.168.0.7:8983/solr"
   IDCacheTTL = -1
   QueryCacheTTL = -1
   MaxReturnedMetadata = 10000

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,6 @@ require (
 	github.com/uol/hashing v1.0.1
 	github.com/uol/logh v1.0.1
 	github.com/uol/restrictedhttpclient v1.0.0
-	github.com/uol/timeline v1.9.3 // indirect
 	github.com/uol/timelinemanager v1.7.2
 	github.com/uol/zencached v1.3.2
-	golang.org/x/sys v0.0.0-20201007165808-a893ed343c85 // indirect
 )

--- a/lib/metadata/keyset.go
+++ b/lib/metadata/keyset.go
@@ -50,6 +50,8 @@ func (sb *SolrBackend) ListKeysets() []string {
 	return sb.getCachedKeysets()
 }
 
+const funcCheckKeyset string = "CheckKeyset"
+
 // CheckKeyset - verifies if an index exists
 func (sb *SolrBackend) CheckKeyset(keyset string) bool {
 
@@ -63,5 +65,6 @@ func (sb *SolrBackend) CheckKeyset(keyset string) bool {
 		}
 	}
 
+	sb.statsMissedKeyset(funcCheckKeyset, keyset)
 	return false
 }

--- a/lib/metadata/stats.go
+++ b/lib/metadata/stats.go
@@ -23,10 +23,10 @@ const (
 	metricSolrRequestError string = "solr.request.error"
 
 	// metricMissedKeyset - metric name for validate keyset fail
-	metricMissedKeyset string = "missed.keyset"
+	metricMissedKeyset string = "keyset.cache.miss"
 
-	// metricZeroKeysets - metric name for collections returned on solr request to list collection with zero length or nil value
-	metricZeroKeysets string = "zero.keysets"
+	// metricListCollectionsEmpty - metric name for collections returned on solr request to list collection with zero length or nil value
+	metricListCollectionsEmpty string = "solr.list.collections.empty"
 
 	// metricListCollectionsError - metric name for solr list collections request error
 	metricListCollectionsError string = "solr.list.collections.error"
@@ -91,7 +91,7 @@ func (sb *SolrBackend) statsZeroKeysets(function string) {
 
 	sb.timelineManager.FlattenCountIncN(
 		function,
-		metricZeroKeysets,
+		metricListCollectionsEmpty,
 	)
 }
 

--- a/lib/metadata/stats.go
+++ b/lib/metadata/stats.go
@@ -21,6 +21,15 @@ const (
 
 	// metricSolrRequestError - metric name for solr request errors
 	metricSolrRequestError string = "solr.request.error"
+
+	// metricMissedKeyset - metric name for validate keyset fail
+	metricMissedKeyset string = "missed.keyset"
+
+	// metricZeroKeysets - metric name for collections returned on solr request to list collection with zero length or nil value
+	metricZeroKeysets string = "zero.keysets"
+
+	// metricListCollectionsError - metric name for solr list collections request error
+	metricListCollectionsError string = "solr.list.collections.error"
 )
 
 // solrOperation - identifies some solr operation
@@ -64,5 +73,33 @@ func (sb *SolrBackend) statsRequest(function, collection, metaType string, opera
 		constants.StringsTargetKSID, utils.ValidateExpectedValue(collection),
 		constants.StringsType, metaType,
 		constants.StringsOperation, operation,
+	)
+}
+
+// statsMissedKeyset - stores a missed keyset statistics
+func (sb *SolrBackend) statsMissedKeyset(function, collection string) {
+
+	sb.timelineManager.FlattenCountIncN(
+		function,
+		metricMissedKeyset,
+		constants.StringsTargetKSID, utils.ValidateExpectedValue(collection),
+	)
+}
+
+// statsZeroKeysets - stores a listed collections length equal to zero statistics
+func (sb *SolrBackend) statsZeroKeysets(function string) {
+
+	sb.timelineManager.FlattenCountIncN(
+		function,
+		metricZeroKeysets,
+	)
+}
+
+// statsListCollectionsError - stores a solr list collections request error
+func (sb *SolrBackend) statsListCollectionsError(function string) {
+
+	sb.timelineManager.FlattenCountIncN(
+		function,
+		metricListCollectionsError,
 	)
 }


### PR DESCRIPTION
Avoiding timeseries to wrong validate existence of a keyset when request to Solr fails.